### PR TITLE
Use \A and \z instead of ^ and $ in DATETIME_REGEX and DATE_REGEX

### DIFF
--- a/lib/allscripts_unity_client/utilities.rb
+++ b/lib/allscripts_unity_client/utilities.rb
@@ -6,8 +6,8 @@ module AllscriptsUnityClient
 
   # Utilities for massaging the data that comes back from Unity.
   class Utilities
-    DATETIME_REGEX = /^((\d{1,2}[-\/]\d{1,2}[-\/]\d{4})|(\d{4}[-\/]\d{1,2}[-\/]\d{1,2})|(\d{1,2}-[A-Za-z]{3,4}-\d{4})|([A-Za-z]{3,4} +\d{1,2} \d{2,4}))(T| +)(\d{1,2}:\d{2}(:\d{2})?(\.\d+)? ?(PM|AM|pm|am)?((-|\+)\d{2}:?\d{2})?Z?)$/
-    DATE_REGEX = /^((\d{1,2}[-\/]\d{1,2}[-\/]\d{4})|(\d{4}[-\/]\d{1,2}[-\/]\d{1,2})|(\d{1,2}-[A-Za-z]{3,4}-\d{4})|([A-Za-z]{3,4} +\d{1,2} \d{2,4}))$/
+    DATETIME_REGEX = /\A((\d{1,2}[-\/]\d{1,2}[-\/]\d{4})|(\d{4}[-\/]\d{1,2}[-\/]\d{1,2})|(\d{1,2}-[A-Za-z]{3,4}-\d{4})|([A-Za-z]{3,4} +\d{1,2} \d{2,4}))(T| +)(\d{1,2}:\d{2}(:\d{2})?(\.\d+)? ?(PM|AM|pm|am)?((-|\+)\d{2}:?\d{2})?Z?)\z/
+    DATE_REGEX = /\A((\d{1,2}[-\/]\d{1,2}[-\/]\d{4})|(\d{4}[-\/]\d{1,2}[-\/]\d{1,2})|(\d{1,2}-[A-Za-z]{3,4}-\d{4})|([A-Za-z]{3,4} +\d{1,2} \d{2,4}))\z/
 
     # Try to encode a string into a Date or ActiveSupport::TimeWithZone object.
     #

--- a/lib/allscripts_unity_client/version.rb
+++ b/lib/allscripts_unity_client/version.rb
@@ -1,3 +1,3 @@
 module AllscriptsUnityClient
-  VERSION = '3.1.1'
+  VERSION = '3.1.2'
 end

--- a/spec/utilities_spec.rb
+++ b/spec/utilities_spec.rb
@@ -31,6 +31,8 @@ describe AllscriptsUnityClient::Utilities do
   let(:date_two) { Date.parse(date_string_two) }
   let(:date_three) { Date.parse(date_string_three) }
 
+  let(:invalid_date_string_one) { "32-13-2014\n02/21/2014"}
+
   describe '.try_to_encode_as_date' do
     context 'when given nil' do
       it { expect(subject.try_to_encode_as_date(timezone, nil)).to be_nil }
@@ -93,6 +95,12 @@ describe AllscriptsUnityClient::Utilities do
     context 'when given a non-date string' do
       it 'returns that string' do
         expect(subject.try_to_encode_as_date(timezone, string)).to eq(string)
+      end
+    end
+
+    context 'when given an invalid date string' do
+      it 'returns that string' do
+        expect(subject.try_to_encode_as_date(timezone, invalid_date_string_one)).to eq(invalid_date_string_one)
       end
     end
   end


### PR DESCRIPTION
This fixes a bug in `AllscriptsUnityClient::UnityResponse.convert_dates_to_utc` where attempting to call
`AllscriptsUnityClient::Utilities.try_to_encode_as_date` with the value of the 'XMLDetail' field would result in `Date.parse` to fail.

This has been tested and verified in a REPL session; specs pending.