### PR TITLE
Add denyreason as an available SavetaskStatus parameter6 option

### DIFF
--- a/lib/allscripts_unity_client/client.rb
+++ b/lib/allscripts_unity_client/client.rb
@@ -704,6 +704,7 @@ module AllscriptsUnityClient
           xml.delegated('value' => taskchanges[:delegated]) unless taskchanges.nil? || taskchanges[:delegated].nil?
           xml.taskstatus('value' => taskchanges[:taskstatus]) unless taskchanges.nil? || taskchanges[:taskstatus].nil?
           xml.removereason('value' => taskchanges[:removereason]) unless taskchanges.nil? || taskchanges[:removereason].nil?
+          xml.denyreason('value' => taskchanges[:denyreason]) unless taskchanges.nil? || taskchanges[:denyreason].nil?
         }
       end
 

--- a/lib/allscripts_unity_client/version.rb
+++ b/lib/allscripts_unity_client/version.rb
@@ -1,3 +1,3 @@
 module AllscriptsUnityClient
-  VERSION = '3.1.2'
+  VERSION = '3.1.3'
 end


### PR DESCRIPTION
We already have the infrastructure in place to take different parameter6 Task Status change fields (such as "delegated" and "taskstatus" but we don't yet have an option for denyreason. This change will allow the integration_service to send a denyreason key and value for parameter6 and allow the Unity call to successfully send this.