### PR TITLE
Save task status requires patient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.2
+
+install:
+  - "gem install bundler"
+  - "bundle install --jobs=3 --retry=3"

--- a/lib/allscripts_unity_client/client.rb
+++ b/lib/allscripts_unity_client/client.rb
@@ -222,7 +222,7 @@ module AllscriptsUnityClient
     # @param [Object] show_past_flag whether to show previous
     #   encounters. All truthy values aside from the string `"N"` are
     #   considered to be true (or `"Y"`) all other values are
-    #   considered to be false (or `"N"`). Defaults to `true`.  
+    #   considered to be false (or `"N"`). Defaults to `true`.
     # @param [Object] billing_provider_user_name filter by user
     #   name. Defaults to `nil`.
     # @param [Object] show_all
@@ -711,13 +711,17 @@ module AllscriptsUnityClient
       magic_parameters = {
         action: 'SaveTaskStatus',
         userid: userid,
-        patientid: patient_id,
         parameter1: transaction_id,
         parameter2: status,
         parameter3: delegate_id,
         parameter4: comment,
         parameter6: nokogiri_to_string(builder)
       }
+
+      if patient_id
+        magic_parameters.update(patientid: patient_id)
+      end
+
       magic(magic_parameters)
     end
 

--- a/lib/allscripts_unity_client/client.rb
+++ b/lib/allscripts_unity_client/client.rb
@@ -694,10 +694,6 @@ module AllscriptsUnityClient
         raise ArugmentError, 'transaction_id, delegate_id, and comment can not all be nil'
       end
 
-      if patient_id.nil?
-        warn 'patient_id is required in Unity APIs born after 2015-12-09'
-      end
-
       # Generate XML structure for rxxml
       builder = Nokogiri::XML::Builder.new do |xml|
         xml.taskchanges {

--- a/lib/allscripts_unity_client/client.rb
+++ b/lib/allscripts_unity_client/client.rb
@@ -690,8 +690,8 @@ module AllscriptsUnityClient
     end
 
     def save_task_status(userid, transaction_id = nil, status = nil, delegate_id = nil, comment = nil, taskchanges = nil)
-      if transaction_id.nil? && param.nil? && delegate_id.nil? && comment.nil?
-        raise ArugmentError, 'task_type, target_user, work_object_id, and comments can not all be nil'
+      if transaction_id.nil? && delegate_id.nil? && comment.nil?
+        raise ArugmentError, 'transaction_id, delegate_id, and comment can not all be nil'
       end
 
       # Generate XML structure for rxxml

--- a/lib/allscripts_unity_client/client.rb
+++ b/lib/allscripts_unity_client/client.rb
@@ -689,9 +689,13 @@ module AllscriptsUnityClient
       magic(magic_parameters)
     end
 
-    def save_task_status(userid, transaction_id = nil, status = nil, delegate_id = nil, comment = nil, taskchanges = nil)
+    def save_task_status(userid, transaction_id = nil, status = nil, delegate_id = nil, comment = nil, taskchanges = nil, patient_id = nil)
       if transaction_id.nil? && delegate_id.nil? && comment.nil?
         raise ArugmentError, 'transaction_id, delegate_id, and comment can not all be nil'
+      end
+
+      if patient_id.nil?
+        warn 'patient_id is required in Unity APIs born after 2015-12-09'
       end
 
       # Generate XML structure for rxxml
@@ -711,6 +715,7 @@ module AllscriptsUnityClient
       magic_parameters = {
         action: 'SaveTaskStatus',
         userid: userid,
+        patientid: patient_id,
         parameter1: transaction_id,
         parameter2: status,
         parameter3: delegate_id,


### PR DESCRIPTION
For Unity versions born on Wed, 09 Dec 2015, calls to `SaveTaskStatus` require a `PatientID` parameter. According to the Unity folks, _only_ this version will require a `PatientID` parameter; that is, future versions will optionally take it. [From the developer forums](http://allscripts.vanillacommunity.com/discussion/48/is-the-savetaskstatus-patient-id-parameter-backwards-compatible):

> If you pass it in, we'll check to make sure that is the correct patient associated with that particular task. Otherwise we won't check the patientid. 

The call will work as it did before if you continue to not specify the Patient ID. The `PatientID` parameter will only be included in the magic request if it is given.