### PR TITLE
Fix JSONClientDriver logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
   - 2.1.2
   - 2.2.2
 before_install:

--- a/lib/allscripts_unity_client/json_client_driver.rb
+++ b/lib/allscripts_unity_client/json_client_driver.rb
@@ -88,6 +88,8 @@ module AllscriptsUnityClient
       end_timer
 
       log_get_security_token
+      log_info("Response Status: #{response.status}")
+
       raise_if_response_error(response.body)
 
       @security_token = response.body

--- a/lib/allscripts_unity_client/json_client_driver.rb
+++ b/lib/allscripts_unity_client/json_client_driver.rb
@@ -87,8 +87,8 @@ module AllscriptsUnityClient
       response = @connection.post(build_uri('GetToken'), MultiJson.dump(request_data.to_hash))
       end_timer
 
-      raise_if_response_error(response.body)
       log_get_security_token
+      raise_if_response_error(response.body)
 
       @security_token = response.body
     end

--- a/lib/allscripts_unity_client/json_client_driver.rb
+++ b/lib/allscripts_unity_client/json_client_driver.rb
@@ -49,16 +49,20 @@ module AllscriptsUnityClient
 
     def magic(parameters = {})
       request = JSONUnityRequest.new(parameters, @options.timezone, @options.appname, @security_token)
-      log_magic(request)
-
       request_hash = request.to_hash
-      log_info("Request Data: #{request_hash}")
       request_data = MultiJson.dump(request_hash)
 
       start_timer
       response = @connection.post(build_uri('MagicJson'), request_data)
-      log_info("Response Status: #{response.status}")
       end_timer
+
+      # NOTE: ClientDriver#log_magic uses ClientDriver#log_info, which
+      # appends timing info (if end_timer has been called previously),
+      # and then resets the timer.
+      #
+      # It would be nice if future work made this less stateful.
+      log_magic(request)
+      log_info("Response Status: #{response.status}")
 
       response = MultiJson.load(response.body)
       raise_if_response_error(response)

--- a/spec/json_client_driver_spec.rb
+++ b/spec/json_client_driver_spec.rb
@@ -3,8 +3,16 @@ require 'spec_helper'
 describe AllscriptsUnityClient::JSONClientDriver do
   it_behaves_like 'a client driver'
 
+  let(:fake_logger) do
+    double(Logger)
+  end
+
+  before do
+    allow(fake_logger).to receive(:info)
+  end
+
   subject do
-    client_driver = build(:json_client_driver)
+    client_driver = build(:json_client_driver, logger: fake_logger)
     client_driver.security_token = SecureRandom.uuid
     client_driver
   end
@@ -42,11 +50,6 @@ describe AllscriptsUnityClient::JSONClientDriver do
     before do
       stub_request(:post, "http://www.example.com/Unity/UnityService.svc/json/MagicJson").
                to_return(status: 200, body: get_server_info, headers: {})
-
-      allow(subject).to receive(:start_timer)
-      allow(subject).to receive(:end_timer)
-      allow(subject).to receive(:log_magic)
-      allow(subject).to receive(:log_info).twice
     end
 
     it 'should POST to /Unity/UnityService.svc/json/MagicJson' do
@@ -65,33 +68,22 @@ describe AllscriptsUnityClient::JSONClientDriver do
             )
     end
 
-    it 'should call start_timer' do
-      subject.magic
-      expect(subject).to have_received(:start_timer)
+    it 'should log the request duration' do
+      expect(fake_logger).to receive(:info).with(/Unity API Magic request to [^ ]+ \[SomeRequest\] [0-9.]+ seconds/)
+
+      subject.magic(action: 'SomeRequest')
     end
 
-    it 'should call end_timer' do
-      subject.magic
-      expect(subject).to have_received(:start_timer)
-    end
+    it 'should log the response code' do
+      expect(fake_logger).to receive(:info).with(/Response Status: 200/)
 
-    it 'should call log_magic' do
-      subject.magic
-      expect(subject).to have_received(:log_magic)
-    end
-
-    it 'should call log_info for recording request data and response status' do
-      subject.magic
-      expect(subject).to have_received(:log_info).twice
+      subject.magic(action: 'SomeRequest')
     end
   end
 
   describe '#get_security_token!' do
     before(:each) {
       stub_request(:post, 'http://www.example.com/Unity/UnityService.svc/json/GetToken').to_return(body: get_security_token)
-      allow(subject).to receive(:start_timer)
-      allow(subject).to receive(:end_timer)
-      allow(subject).to receive(:log_get_security_token)
     }
 
     it 'should POST to /Unity/UnityService.svc/json/GetToken with username, password, and appname' do
@@ -99,43 +91,22 @@ describe AllscriptsUnityClient::JSONClientDriver do
       expect(WebMock).to have_requested(:post, 'http://www.example.com/Unity/UnityService.svc/json/GetToken').with(body: /\{"Username":"[^"]+","Password":"[^"]+","Appname":"[^"]+"\}/, headers: { 'Content-Type' => 'application/json' })
     end
 
-    it 'should call start_timer' do
-      subject.get_security_token!
-      expect(subject).to have_received(:start_timer)
-    end
+    it 'log the request to get a security token' do
+      expect(fake_logger).to receive(:info).with(/Unity API GetSecurityToken request to [^ ]+ [0-9.]+ seconds/)
 
-    it 'should call end_timer' do
       subject.get_security_token!
-      expect(subject).to have_received(:start_timer)
-    end
-
-    it 'should call log_get_security_token' do
-      subject.get_security_token!
-      expect(subject).to have_received(:log_get_security_token)
     end
   end
 
   describe '#retire_security_token!' do
     before(:each) {
       stub_request(:post, 'http://www.example.com/Unity/UnityService.svc/json/RetireSecurityToken').to_return(body: retire_security_token)
-      allow(subject).to receive(:start_timer)
-      allow(subject).to receive(:end_timer)
       allow(subject).to receive(:log_retire_security_token)
     }
 
     it 'should POST to /Unity/UnityService.svc/json/RetireSecurityToken with token and appname' do
       subject.retire_security_token!
       expect(WebMock).to have_requested(:post, 'http://www.example.com/Unity/UnityService.svc/json/RetireSecurityToken').with(body: /\{"Token":"[^"]+","Appname":"[^"]+"\}/, headers: { 'Content-Type' => 'application/json' })
-    end
-
-    it 'should call start_timer' do
-      subject.retire_security_token!
-      expect(subject).to have_received(:start_timer)
-    end
-
-    it 'should call end_timer' do
-      subject.retire_security_token!
-      expect(subject).to have_received(:start_timer)
     end
 
     it 'should call log_retire_security_token' do

--- a/spec/json_client_driver_spec.rb
+++ b/spec/json_client_driver_spec.rb
@@ -96,6 +96,12 @@ describe AllscriptsUnityClient::JSONClientDriver do
 
       subject.get_security_token!
     end
+
+    it 'logs the response code from getting a security token' do
+      expect(fake_logger).to receive(:info).with(/Response Status: 200/)
+
+      subject.get_security_token!
+    end
   end
 
   describe '#retire_security_token!' do

--- a/spec/support/shared_examples_for_unity_request.rb
+++ b/spec/support/shared_examples_for_unity_request.rb
@@ -81,7 +81,8 @@ shared_examples 'a unity request' do
 
     context 'when given a UTC date time string' do
       it 'returns an ISO8601 string' do
-        now_iso8601 = DateTime.now.utc.iso8601
+        now = DateTime.now.utc
+        now_iso8601 = now.strftime('%Y-%m-%dT%H:%M:%S%:z')
         expect(subject.send(:process_date, now_iso8601)).to eq(now_iso8601)
       end
     end
@@ -97,7 +98,7 @@ shared_examples 'a unity request' do
     context 'when given a UTC Time' do
       it 'returns an ISO8601 string' do
         now = Time.now.utc
-        now_iso8601 = now.strftime('%Y-%m-%dT%H:%M:%S+00:00')
+        now_iso8601 = now.strftime('%Y-%m-%dT%H:%M:%S%:z')
         expect(subject.send(:process_date, now)).to eq(now_iso8601)
       end
     end
@@ -105,7 +106,7 @@ shared_examples 'a unity request' do
     context 'when given a UTC DateTime' do
       it 'returns an ISO8601 string' do
         now = DateTime.now.utc
-        now_iso8601 = now.iso8601
+        now_iso8601 = now.strftime('%Y-%m-%dT%H:%M:%S%:z')
         expect(subject.send(:process_date, now)).to eq(now_iso8601)
       end
     end


### PR DESCRIPTION
5c6e05a changed how requests/responses were logged, and inadvertently introduced a bug where response time info would not be logged correctly. The implementation of the timer made such a bug easy to introduce, since the timer state is tightly coupled with logging a message after `end_timer` has been called.

This change does not improve the timer implementation at all, but it does rectify the broken assumption. The line which logs request details should now contain both the "magic" action used and the duration of the request. The tests have been adjusted to exercise as much, rather than that the superclass interface was being used in a certain way.

---

I've also tweaked a few other things that popped up in reviewing `JSONClientDriver` and in fixing the build:

1. `GetSecurityToken` logs the request duration and the response status before it raises in the event of an error.
1. The tests for `process_date` are no longer flaky depending on where they are run