### PR TITLE
Raise on non 200 response code from GetSecurityToken

### DIFF
--- a/lib/allscripts_unity_client.rb
+++ b/lib/allscripts_unity_client.rb
@@ -17,6 +17,10 @@ module AllscriptsUnityClient
   class APIError < RuntimeError
   end
 
+  # Raised whenever the security token could not be retrieved Unity.
+  class GetSecurityTokenError < RuntimeError
+  end
+
   # Create an instance of the Unity client.
   #
   # options:: See ClientOptions.

--- a/lib/allscripts_unity_client/client_driver.rb
+++ b/lib/allscripts_unity_client/client_driver.rb
@@ -75,5 +75,15 @@ module AllscriptsUnityClient
       @end_time = Time.now.utc
       @timer = @end_time - @start_time
     end
+
+    # Initializes a `GetSecurityTokenError` with a default message.
+    #
+    # @return [GetSecurityTokenError]
+    def make_get_security_token_error
+      base_unity_url = self.options.base_unity_url.inspect
+      error_message = "Could not retrieve security token from #{base_unity_url}"
+
+      GetSecurityTokenError.new(error_message)
+    end
   end
 end

--- a/lib/allscripts_unity_client/json_client_driver.rb
+++ b/lib/allscripts_unity_client/json_client_driver.rb
@@ -12,7 +12,6 @@ module AllscriptsUnityClient
     def initialize(options)
       super
 
-
       @connection = HTTPClient.new(
         proxy: @options.proxy,
         default_header: {'Content-Type' => 'application/json'}
@@ -90,9 +89,13 @@ module AllscriptsUnityClient
       log_get_security_token
       log_info("Response Status: #{response.status}")
 
-      raise_if_response_error(response.body)
+      if response.status != 200
+        raise make_get_security_token_error
+      else
+        raise_if_response_error(response)
 
-      @security_token = response.body
+        @security_token = response.body
+      end
     end
 
     # See Client#retire_security_token!.
@@ -117,6 +120,14 @@ module AllscriptsUnityClient
 
     private
 
+    # @param [Array,String,nil] response
+    #
+    # @return [nil]
+    #
+    # @todo This method should be responsible creating an `APIError` not
+    # raising it. The sender should be responsible for raising the
+    # error so the stack trace starts in the method where the failure
+    # occured.
     def raise_if_response_error(response)
       if response.nil?
         raise APIError, 'Response was empty'

--- a/lib/allscripts_unity_client/version.rb
+++ b/lib/allscripts_unity_client/version.rb
@@ -1,3 +1,3 @@
 module AllscriptsUnityClient
-  VERSION = '3.3.1'
+  VERSION = '3.4.0'
 end

--- a/spec/json_client_driver_spec.rb
+++ b/spec/json_client_driver_spec.rb
@@ -102,6 +102,21 @@ describe AllscriptsUnityClient::JSONClientDriver do
 
       subject.get_security_token!
     end
+
+    it 'should fail when there is a problem retrieving the security token' do
+      stub_request(:post, 'http://www.example.com/Unity/UnityService.svc/json/GetToken')
+        .to_return(
+          {
+            body: "",
+            headers: {},
+            status: 503,
+          }
+        )
+
+      expect do
+        subject.get_security_token!
+      end.to raise_error(AllscriptsUnityClient::GetSecurityTokenError)
+    end
   end
 
   describe '#retire_security_token!' do


### PR DESCRIPTION
When `GetSecurityToken` fails with a non-200 response status code the client remains in a usable state permitting subsequent calls to Unity to be carried out with an invalid security token. When those subsequent calls fail they typically fail with a JSON parse error which make it appear as if the problem is with the response body when in fact the problem is with the invalid security token.

This patch defines a `GetSecurityTokenError` which is raised in the event a non-200 status code is returned while attempting to retrieve the security token. AFAICT this okay because we have some, although not complete, error handling in the 200 branch.

I have discovered there are instances where we can get a 200 status code with an error message in the response body. For example, requesting a security token with a bad `username` can have a response body `"Error: Service Application not licensed on this server!"` yet the status code for the response is 200. I won't address this failure mode in this PR, however. :skull_and_crossbones: 