### PR TITLE
Rescue date parsing errors in try_to_encode_as_date

### DIFF
--- a/lib/allscripts_unity_client/utilities.rb
+++ b/lib/allscripts_unity_client/utilities.rb
@@ -18,18 +18,19 @@ module AllscriptsUnityClient
     #
     # Returns Date or ActiveSupport::TimeWithZone, or the string if it did not contain a date.
     def self.try_to_encode_as_date(timezone, possible_date)
-      if possible_date.nil?
-        return nil
+      case possible_date
+      when DATE_REGEX
+        Date.parse(possible_date)
+      when DATETIME_REGEX
+        timezone.parse(possible_date)
+      else
+        possible_date
       end
-
-      if possible_date.is_a?(String) && possible_date =~ DATE_REGEX
-        return Date.parse(possible_date)
-      end
-
-      if possible_date.is_a?(String) && possible_date =~ DATETIME_REGEX
-        return timezone.parse(possible_date)
-      end
-
+    # Since we know in either of the cases above we only attempt to
+    # parse a string this is either an "invalid date" from
+    # `Date.parse` or an "argument out of range" from
+    # `ActiveSupport::TimeZone#parse`.
+    rescue ArgumentError
       possible_date
     end
 

--- a/lib/allscripts_unity_client/version.rb
+++ b/lib/allscripts_unity_client/version.rb
@@ -1,3 +1,3 @@
 module AllscriptsUnityClient
-  VERSION = '3.4.0'
+  VERSION = '3.4.1'.freeze
 end

--- a/spec/utilities_spec.rb
+++ b/spec/utilities_spec.rb
@@ -103,6 +103,15 @@ describe AllscriptsUnityClient::Utilities do
         expect(subject.try_to_encode_as_date(timezone, invalid_date_string_one)).to eq(invalid_date_string_one)
       end
     end
+
+    context 'when givn an valid date string that represents an invalid date' do
+      it 'it returns the string' do
+        date = "10/00/1999"
+        date_time = "10/00/1999 01:01:01"
+        expect(subject.try_to_encode_as_date(timezone, date)).to be(date)
+        expect(subject.try_to_encode_as_date(timezone, date_time)).to be(date_time)
+      end
+    end
   end
 
   describe '.encode_data' do


### PR DESCRIPTION
A date string can fit a date or date time regular expression but be an invalid date when parsed. For example, the sting `"10/00/1999"` will satisfy the regular expression given by `DATE_REGEX` but fail when given to `Date.parse`. In these situations we simply rescue the error the return the string.