### PR TITLE
removes travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: ruby
-rvm:
-  - 2.4.2 # This is the version we run currently
-  - 2.4.9
-  - 2.5.7
-install:
-  - "gem install bundler"
-  - "bundle install --jobs=3 --retry=3"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Allscripts Unity Client [![Build Status](https://travis-ci.org/healthfinch/allscripts-unity-client.png?branch=master)](https://travis-ci.org/healthfinch/allscripts-unity-client) [![Coverage Status](https://coveralls.io/repos/healthfinch/allscripts-unity-client/badge.png?branch=master)](https://coveralls.io/r/healthfinch/allscripts-unity-client?branch=master)
+# Allscripts Unity Client [![CircleCI](https://circleci.com/gh/healthfinch/allscripts-unity-client.svg?style=svg)](https://circleci.com/gh/healthfinch/allscripts-unity-client) [![Coverage Status](https://coveralls.io/repos/healthfinch/allscripts-unity-client/badge.png?branch=master)](https://coveralls.io/r/healthfinch/allscripts-unity-client?branch=master)
 
 The `allscripts_unity_client` gem is a Ruby client for the Allscripts Unity API. See http://remotecentral.allscripts.com/UnityAPIReference for more documentation on the API.
 


### PR DESCRIPTION
# What

Removes the Travis CI configuration.

# Why

We use CircleCI, so this was just wasting time and resources.