### PR TITLE
only try to build the gem when the version has changed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,11 @@ jobs:
       - image: circleci/ruby:2.4.9
     steps:
       - checkout
+      - run:
+          name: Determine if gem build is needed
+          command: |
+            git log -m -1 --name-only --pretty="format:%d" -n 1 | grep -q "version.rb" \
+            && circleci-agent step halt
       - add_ssh_keys:
           fingerprints:
             - "5a:d3:92:32:b0:46:28:75:56:e9:ac:51:cc:44:31:82"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - run:
           name: Determine if gem build is needed
           command: |
-            git log -m -1 --name-only --pretty="format:%d" -n 1 | grep -q "version.rb" \
+            git diff --name-only HEAD^..HEAD | grep -q version.rb \
             && circleci-agent step halt
       - add_ssh_keys:
           fingerprints:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           name: Determine if gem build is needed
           command: |
             git diff --name-only HEAD^..HEAD | grep -q version.rb \
-            && circleci-agent step halt
+              && circleci-agent step halt
       - add_ssh_keys:
           fingerprints:
             - "5a:d3:92:32:b0:46:28:75:56:e9:ac:51:cc:44:31:82"


### PR DESCRIPTION
# What

Look to see if the `version.rb` file has changed before trying to build the gem.

# Why

So we don't fail a bunch of builds on master because you can't build the same gem twice.
