### PR TITLE
Really fixes the gem build issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,9 @@ jobs:
       - run:
           name: Determine if gem build is needed
           command: |
-            git diff --name-only HEAD^..HEAD | grep -q version.rb \
-              && circleci-agent step halt
+            if ! git diff --name-only HEAD^..HEAD | grep -q version.rb; then
+              circleci-agent step halt
+            fi
       - add_ssh_keys:
           fingerprints:
             - "5a:d3:92:32:b0:46:28:75:56:e9:ac:51:cc:44:31:82"


### PR DESCRIPTION
# What

Actually fix the gem build issue.

# How

In a previous version, I had

![image](https://user-images.githubusercontent.com/57365220/72457901-92c10700-3795-11ea-863a-62d4fa187337.png)

I now realize that when `grep` doesn't find anything, it returns a `1` exit code. So the build exited with a status code of `1`. Ouch.

To avoid this problem, I've changed the `grep` to be inside a conditional, so we are explicitly looking at that status code instead of failing if it isn't `0`.

To test this, I moved the changes up into the test stage and changed the file I was looking at to the config file for circle. You can see in this build https://circleci.com/gh/healthfinch/allscripts-unity-client/180 that when I abort if `config.rb` (the wrong ending) isn't in the changeset, then the build actually aborts:
![image](https://user-images.githubusercontent.com/57365220/72458148-0b27c800-3796-11ea-9fa2-b4564401f82c.png)


And then in https://circleci.com/gh/healthfinch/allscripts-unity-client/181 you'll see that since the `config.yml` file *was* changed, we continue with the build (in this case the build is a test run): 
![image](https://user-images.githubusercontent.com/57365220/72458217-2bf01d80-3796-11ea-95cb-a2bcb88da8a6.png)

In the config file now you'll see I'm doing the same thing for the gem build process: putting the `grep` check inside a conditional and only halting if the file *is not* in the changeset.