### PR TITLE
Fixes typo in auth failure log

### DIFF
--- a/lib/allscripts_unity_client/json_client_driver.rb
+++ b/lib/allscripts_unity_client/json_client_driver.rb
@@ -87,7 +87,7 @@ module AllscriptsUnityClient
         log_info("Successful authentication attempt for #{@options.base_unity_url}")
         return true
       elsif response[:valid_user] == 'NO'
-        log_info("Unuccessful authentication attempt for #{@options.base_unity_url}")
+        log_info("Unsuccessful authentication attempt for #{@options.base_unity_url}")
         return false
       else
         raise StandardError.new('Unexpected response from the server')

--- a/lib/allscripts_unity_client/version.rb
+++ b/lib/allscripts_unity_client/version.rb
@@ -1,3 +1,3 @@
 module AllscriptsUnityClient
-  VERSION = '5.0.1-alpha'.freeze
+  VERSION = '5.0.0-alpha.1'.freeze
 end

--- a/lib/allscripts_unity_client/version.rb
+++ b/lib/allscripts_unity_client/version.rb
@@ -1,3 +1,3 @@
 module AllscriptsUnityClient
-  VERSION = '5.0.0-alpha'.freeze
+  VERSION = '5.0.1-alpha'.freeze
 end


### PR DESCRIPTION
# What

`s/Unuccessful/Unsuccessful` when logging about failed authentication attempts.

ALSO this bumps the micro version of the gem, mostly so I can test that the CircleCI build works. This change doesn't really warrant a release, but it also doesn't seem ridiculous to do a micro release here.
