### PR TITLE
adds our standard HITRUST PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,51 @@
+### Story Card: [PD-###](https://healthfinch.atlassian.net/browse/PD-###)
+
+## Description of Change
+
+
+## Testing Procedures to Verify the Functionality from this Change
+_See Jira Card for testing details_
+
+
+## Description of Deployment and Rollback Procedures
+### Deployment
+- [ ] Deployment follows standard [procedure](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/781189280/Deployment+Procedure+s)
+
+If deployment does not follow standard procedure please explain the deployment process for this PR.
+
+
+### Rollback
+- [ ] Rollback follows standard [procedure](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/779583813/Deployment+Rollback+Procedure+s)
+
+If rollback does not follow standard procedure please explain the deployment process for this PR.
+
+## Related Information (e.g., Pull requests, story cards, bug reports, metrics, logs, etc.):
+
+
+## Process Checks
+
+- [ ] Story card has been accepted by requester
+
+- [ ] Local run of tests have been completed
+
+- [ ] Has been deployed and tested in Stage
+
+- [ ] This was worked on in a pair
+
+If any of the above boxes were not checked please explain why:
+
+
+## Security
+
+- [ ] This Pull Request does not introduce a new break of any of our [Informational Security Policies](https://healthfinch.atlassian.net/wiki/spaces/COM/pages/33423408/Information+Security+Policies)
+
+- [ ] This Pull Request does not create new ingress or egress rules, including opening any new ports
+
+- [ ] This Pull Request has been evaluated by all [OWASP principles](https://www.owasp.org/index.php/Category:Principle) and does not introduce any gaps in security
+
+If any of the above boxes were not checked please explain why:
+
+
+### Other Comments
+
+** If all checkbox answers are yes above this change is pre-approved by manager of the application and can be merged with a Pull Request approval. If any of the boxes are unchecked the manager responsible for the application has the ability to approve the change and take on the risk.


### PR DESCRIPTION
### Story Card: N/A

## Description of Change

Adds our standard HITRUST PR template to this gem. I talked with CJ, Chae, and Chris Tyne about whether to use this template or something else given that (a) this gem is public and (b) you can't really follow it unless you work at healthfinch since all the documentation links are internal, but Chris pointed out that since we haven't had any outside contributors in ages, we could just do the simple thing here and get more complicated if the need arises.

## Testing Procedures to Verify the Functionality from this Change
Documentation update that does not require changes.

## Description of Deployment and Rollback Procedures
### Deployment
- [x] Deployment follows standard [procedure](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/781189280/Deployment+Procedure+s)

If deployment does not follow standard procedure please explain the deployment process for this PR.


### Rollback
- [x] Rollback follows standard [procedure](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/779583813/Deployment+Rollback+Procedure+s)

If rollback does not follow standard procedure please explain the deployment process for this PR.

## Related Information (e.g., Pull requests, story cards, bug reports, metrics, logs, etc.):


## Process Checks

- [x] Story card has been accepted by requester

- [x] Local run of tests have been completed

- [ ] Has been deployed and tested in Stage

- [ ] This was worked on in a pair

If any of the above boxes were not checked please explain why:


## Security

- [x] This Pull Request does not introduce a new break of any of our [Informational Security Policies](https://healthfinch.atlassian.net/wiki/spaces/COM/pages/33423408/Information+Security+Policies)

- [x] This Pull Request does not create new ingress or egress rules, including opening any new ports

- [x] This Pull Request has been evaluated by all [OWASP principles](https://www.owasp.org/index.php/Category:Principle) and does not introduce any gaps in security

If any of the above boxes were not checked please explain why:


### Other Comments

** If all checkbox answers are yes above this change is pre-approved by manager of the application and can be merged with a Pull Request approval. If any of the boxes are unchecked the manager responsible for the application has the ability to approve the change and take on the risk.
