### PR TITLE
Removed Other Comments section under Security that is leftover from l…

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,14 +42,20 @@ If any of the above boxes were not checked please explain why:
 
 This Pull Request:
 
-- [ ] DOES / [ ] DOES NOT change any external input or output
-
-- [ ] DOES / [ ] DOES NOT change authentication, access control or password management
-
-- [ ] DOES / [ ] DOES NOT change transmission or storage of secure data
-
-- [ ] DOES / [ ] DOES NOT change error handling or logging
-
-- [ ] DOES / [ ] DOES NOT contain any database or data file changes
+- Changes any external input or output
+    - [ ] DOES
+    - [ ] DOES NOT
+- Changes authentication, access control or password management
+    - [ ] DOES
+    - [ ] DOES NOT
+- Changes transmission or storage of secure data
+    - [ ] DOES
+    - [ ] DOES NOT
+- Changes error handling or logging
+    - [ ] DOES
+    - [ ] DOES NOT
+- Contains any database or data file changes
+    - [ ] DOES
+    - [ ] DOES NOT
 
 If DOES was answered for any of the above security questions, use the [Secure Coding Guidelines](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/1271824607/Secure+Coding+Guidelines) checklist and detail the results here:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -53,8 +53,3 @@ This Pull Request:
 - [ ] DOES / [ ] DOES NOT contain any database or data file changes
 
 If DOES was answered for any of the above security questions, use the [Secure Coding Guidelines](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/1271824607/Secure+Coding+Guidelines) checklist and detail the results here:
-
-
-### Other Comments
-
-** If all checkbox answers are yes above this change is pre-approved by manager of the application and can be merged with a Pull Request approval. If any of the boxes are unchecked the manager responsible for the application has the ability to approve the change and take on the risk.


### PR DESCRIPTION
…ast change to Security.

### Story Card: N/A

## Description of Change

Updating security portion of the GitHub Pull Request (PR) template to remove unnecessary Other Comments section.

## Testing Procedures to Verify the Functionality from this Change

Future PRs will contain the new checklist.

## Description of Deployment and Rollback Procedures
### Deployment
- [x] Deployment follows standard [procedure](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/781189280/Deployment+Procedure+s)

If deployment does not follow standard procedure please explain the deployment process for this PR.


### Rollback
- [x] Rollback follows standard [procedure](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/779583813/Deployment+Rollback+Procedure+s)

If rollback does not follow standard procedure please explain the deployment process for this PR.

## Related Information (e.g., Pull requests, story cards, bug reports, metrics, logs, etc.):


## Process Checks

- [ ] Story card has been accepted by requester

- [ ] Local run of tests have been completed

- [ ] Has been deployed and tested in Stage

- [ ] This was worked on in a pair

If any of the above boxes were not checked please explain why:

N/A - template only change for GitHub pull requests.

## Security

[Secure Coding Guidelines](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/1271824607/Secure+Coding+Guidelines)
[Informational Security Policies](https://healthfinch.atlassian.net/wiki/spaces/COM/pages/33423408/Information+Security+Policies)

This Pull Request:

- Changes any external input or output
    - [ ] DOES
    - [x] DOES NOT
- Changes authentication, access control or password management
    - [ ] DOES
    - [x] DOES NOT
- Changes transmission or storage of secure data
    - [ ] DOES
    - [x] DOES NOT
- Changes error handling or logging
    - [ ] DOES
    - [x] DOES NOT
- Contains any database or data file changes
    - [ ] DOES
    - [x] DOES NOT

If DOES was answered for any of the above security questions, use the [Secure Coding Guidelines](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/1271824607/Secure+Coding+Guidelines) checklist and detail the results here:
