### PR TITLE
[SUST-405] Adds an option to allow dates to be used without any trans…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,7 +41,7 @@ Layout/SpaceAroundKeyword:
   Description: 'Put a space before the modifier keyword.'
   Enabled: true
 
-Layout/Tab:
+Layout/IndentationStyle:
   Description: 'No hard tabs.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-indentation'
   Enabled: true
@@ -219,7 +219,7 @@ Lint/EmptyInterpolation:
   Description: 'Checks for empty string interpolation.'
   Enabled: true
 
-Lint/EndInMethod:
+Style/EndBlock:
   Description: 'END blocks should not be placed inside method definitions.'
   Enabled: true
 
@@ -315,10 +315,6 @@ Lint/UselessAccessModifier:
 Lint/UselessAssignment:
   Description: 'Checks for useless assignment to a local variable.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars'
-  Enabled: true
-
-Lint/UselessComparison:
-  Description: 'Checks for comparison of something with itself.'
   Enabled: true
 
 Lint/UselessElseWithoutRescue:

--- a/lib/allscripts_unity_client.rb
+++ b/lib/allscripts_unity_client.rb
@@ -31,6 +31,7 @@ module AllscriptsUnityClient
   # Returns an instance of Client.
   def self.create(options = {})
     options[:mode] ||= :json
+    options[:raw_dates] ||= false
     if options[:log] != false # explicitly
       options[:log] = true
     end

--- a/lib/allscripts_unity_client/client_options.rb
+++ b/lib/allscripts_unity_client/client_options.rb
@@ -3,7 +3,7 @@ module AllscriptsUnityClient
   # Contains various options for Unity configuration.
   class ClientOptions
     attr_accessor :proxy, :logger, :ca_file, :ca_path, :timeout, :ehr_userid, :ehr_password
-    attr_reader :base_unity_url, :username, :password, :appname, :timezone
+    attr_reader :base_unity_url, :username, :password, :appname, :timezone, :raw_dates
 
     # Constructor.
     #
@@ -34,6 +34,7 @@ module AllscriptsUnityClient
 
       self.timezone = options[:timezone]
       self.base_unity_url = options[:base_unity_url]
+      self.raw_dates = options[:raw_dates]
 
       validate_options
     end
@@ -94,6 +95,10 @@ module AllscriptsUnityClient
       else
         @timezone = ActiveSupport::TimeZone['Etc/UTC']
       end
+    end
+
+    def raw_dates=(raw_dates)
+      @raw_dates = raw_dates || false
     end
 
     # Return true if proxy is set and not empty.

--- a/lib/allscripts_unity_client/json_client_driver.rb
+++ b/lib/allscripts_unity_client/json_client_driver.rb
@@ -52,7 +52,7 @@ module AllscriptsUnityClient
         raise UnauthenticatedError, "#{parameters[:action]} for #{@options.base_unity_url}"
       end
 
-      request = JSONUnityRequest.new(parameters, @options.timezone, @options.appname, @security_token)
+      request = JSONUnityRequest.new(parameters, @options.timezone, @options.appname, @security_token, @options.raw_dates)
       request_hash = request.to_hash
       request_data = MultiJson.dump(request_hash)
 

--- a/lib/allscripts_unity_client/unity_request.rb
+++ b/lib/allscripts_unity_client/unity_request.rb
@@ -2,7 +2,7 @@ module AllscriptsUnityClient
 
   # Transform a Unity request into a Hash suitable for sending using Savon.
   class UnityRequest
-    attr_accessor :parameters, :appname, :security_token, :timezone
+    attr_accessor :parameters, :appname, :security_token, :timezone, :raw_dates
 
     # Constructor.
     #
@@ -26,7 +26,7 @@ module AllscriptsUnityClient
     # timezone:: An ActiveSupport::TimeZone instance.
     # appname:: The Unity license appname.
     # security_token:: A security token from the Unity GetSecurityToken call.
-    def initialize(parameters, timezone, appname, security_token)
+    def initialize(parameters, timezone, appname, security_token, raw_dates=false)
       raise ArgumentError, 'parameters can not be nil' if parameters.nil?
       raise ArgumentError, 'timezone can not be nil' if timezone.nil?
       raise ArgumentError, 'appname can not be nil' if appname.nil?
@@ -36,6 +36,7 @@ module AllscriptsUnityClient
       @security_token = security_token
       @parameters = parameters
       @timezone = timezone
+      @raw_dates = raw_dates
     end
 
     # Convert the parameters to a Hash for Savon with all possible dates
@@ -72,10 +73,16 @@ module AllscriptsUnityClient
 
     protected
 
+    def use_raw_dates?
+      @raw_dates || false
+    end
+
     def process_date(value)
       if value && (value.is_a?(Time) || value.is_a?(DateTime) || value.is_a?(ActiveSupport::TimeWithZone))
         return value.in_time_zone(@timezone).iso8601
       end
+
+      return value if use_raw_dates?
 
       date = Utilities::try_to_encode_as_date(ActiveSupport::TimeZone['Etc/UTC'], value)
 

--- a/lib/allscripts_unity_client/version.rb
+++ b/lib/allscripts_unity_client/version.rb
@@ -1,3 +1,3 @@
 module AllscriptsUnityClient
-  VERSION = '5.0.0'.freeze
+  VERSION = '5.1.0'.freeze
 end

--- a/spec/allscripts_unity_client_spec.rb
+++ b/spec/allscripts_unity_client_spec.rb
@@ -26,6 +26,31 @@ describe AllscriptsUnityClient do
         expect { subject.create(parameters) }.to raise_error(ArgumentError, ':mode must be :json')
       end
     end
+
+    context 'when given raw_dates true' do
+      it 'returns a client with client_type :json' do
+        parameters = build(:allscripts_unity_client_parameters, mode: :json, raw_dates: true)
+        client = subject.create(parameters)
+        expect(client.client_type).to be(:json)
+      end
+    end
+
+    context 'when given raw_dates false' do
+      it 'returns a client with client_type :json' do
+        parameters = build(:allscripts_unity_client_parameters, mode: :json, raw_dates: false)
+        client = subject.create(parameters)
+        expect(client.client_type).to be(:json)
+      end
+    end
+
+    context 'when not given raw_dates' do
+      it 'returns a json client with raw_dates option defaulted to false' do
+        parameters = build(:allscripts_unity_client_parameters, mode: :json)
+        client = subject.create(parameters)
+        expect(client.options.raw_dates).to be_falsy
+        expect(client.client_type).to be(:json)
+      end
+    end
   end
 
   describe '#save_task' do

--- a/spec/support/shared_examples_for_unity_request.rb
+++ b/spec/support/shared_examples_for_unity_request.rb
@@ -109,5 +109,14 @@ shared_examples 'a unity request' do
         expect(subject.send(:process_date, now)).to eq(now_iso8601)
       end
     end
+
+    context 'when using raw_dates option' do
+      let!(:magic_request2) { build(:magic_request, raw_dates: true) }
+
+      it 'returns the date that was supplied' do
+        now = '03-29-2021 23:59:59.999'
+        expect(subject.send(:process_date, now)).to eq(now)
+      end
+    end
   end
 end


### PR DESCRIPTION
…formations for requests.

### Story Card: [SUST-405](https://healthfinch.atlassian.net/browse/SUST-405)

## Description of Change

This change adds an option `raw_dates` that when set to `true` will cause the `UnityRequest#process_date` method to just return the date that was passed in (to be used as a parameter for unity requests).

## Testing Procedures to Verify the Functionality from this Change
_See Jira Card for testing details_


## Description of Deployment and Rollback Procedures
### Deployment
- [x] Deployment follows standard [procedure](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/781189280/Deployment+Procedure+s)

If deployment does not follow standard procedure please explain the deployment process for this PR.


### Rollback
- [x] Rollback follows standard [procedure](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/779583813/Deployment+Rollback+Procedure+s)

If rollback does not follow standard procedure please explain the deployment process for this PR.

## Related Information (e.g., Pull requests, story cards, bug reports, metrics, logs, etc.):


## Process Checks

- [ ] Story card has been accepted by requester

- [x] Local run of tests have been completed

- [ ] Has been deployed and tested in Stage

- [ ] This was worked on in a pair

If any of the above boxes were not checked please explain why:


## Security

[Secure Coding Guidelines](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/1271824607/Secure+Coding+Guidelines)
[Informational Security Policies](https://healthfinch.atlassian.net/wiki/spaces/COM/pages/33423408/Information+Security+Policies)

This Pull Request:

- Changes any external input or output
    - [ ] DOES
    - [x] DOES NOT
- Changes authentication, access control or password management
    - [ ] DOES
    - [x] DOES NOT
- Changes transmission or storage of secure data
    - [ ] DOES
    - [x] DOES NOT
- Changes error handling or logging
    - [ ] DOES
    - [x] DOES NOT
- Contains any database or data file changes
    - [ ] DOES
    - [x] DOES NOT

If DOES was answered for any of the above security questions, use the [Secure Coding Guidelines](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/1271824607/Secure+Coding+Guidelines) checklist and detail the results here:
