### PR TITLE
SUST-1000

### DIFF
--- a/lib/allscripts_unity_client/client.rb
+++ b/lib/allscripts_unity_client/client.rb
@@ -540,7 +540,8 @@ module AllscriptsUnityClient
         parameter1: since,
         parameter2: task_types,
         parameter3: task_statuses,
-        parameter4: delegated
+        parameter4: delegated,
+        parameter5: 0
       }
       response = magic(magic_parameters)
 

--- a/lib/allscripts_unity_client/version.rb
+++ b/lib/allscripts_unity_client/version.rb
@@ -1,3 +1,3 @@
 module AllscriptsUnityClient
-  VERSION = '5.1.0'.freeze
+  VERSION = '5.1.1'.freeze
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -58,7 +58,7 @@ describe AllscriptsUnityClient::Client do
   end
 
   describe '#get_task_list' do
-    it 'does stuff' do
+    it 'sends with proper parameters' do
       subject.client_driver = double(magic: 'magic')
       subject.get_task_list(123, Date.yesterday.strftime("%m/%d/%Y"),
                             'Y', 'Something|okj', 'Ready|go')
@@ -68,7 +68,8 @@ describe AllscriptsUnityClient::Client do
         parameter1: Date.yesterday.strftime("%m/%d/%Y"),
         parameter2: 'Something|okj',
         parameter3: 'Ready|go',
-        parameter4: 'Y'
+        parameter4: 'Y',
+        parameter5: 0
       }
       expect(subject.client_driver).to have_received(:magic).with(magicified_parameters)
     end


### PR DESCRIPTION
### Story Card: [SUST-1000](https://healthfinch.atlassian.net/browse/SUST-1000)

## Description of Change
Added parameter5 as 0 to the get_task_list call, per Jamieson, to solve issues with a "unable to convert varchar to numeric" issue that arose with Memorial Hospital go live testing.

## Testing Procedures to Verify the Functionality from this Change
_See Jira Card for testing details_


## Description of Deployment and Rollback Procedures
### Deployment
- [x] Deployment follows standard [procedure](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/781189280/Deployment+Procedure+s)

If deployment does not follow standard procedure please explain the deployment process for this PR.


### Rollback
- [x] Rollback follows standard [procedure](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/779583813/Deployment+Rollback+Procedure+s)

If rollback does not follow standard procedure please explain the deployment process for this PR.

## Related Information (e.g., Pull requests, story cards, bug reports, metrics, logs, etc.):


## Process Checks

- [ ] Story card has been accepted by requester

- [x] Local run of tests have been completed

- [x] Has been deployed and tested in Stage

- [ ] This was worked on in a pair

If any of the above boxes were not checked please explain why:
Not paired due to simple change.  Need to build new gem in order to test.

## Security

[Secure Coding Guidelines](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/1271824607/Secure+Coding+Guidelines)
[Informational Security Policies](https://healthfinch.atlassian.net/wiki/spaces/COM/pages/33423408/Information+Security+Policies)

This Pull Request:

- Changes any external input or output
    - [x] DOES
    - [ ] DOES NOT
- Changes authentication, access control or password management
    - [ ] DOES
    - [x] DOES NOT
- Changes transmission or storage of secure data
    - [ ] DOES
    - [x] DOES NOT
- Changes error handling or logging
    - [ ] DOES
    - [x] DOES NOT
- Contains any database or data file changes
    - [ ] DOES
    - [x] DOES NOT

If DOES was answered for any of the above security questions, use the [Secure Coding Guidelines](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/1271824607/Secure+Coding+Guidelines) checklist and detail the results here:

adds a 0 to the parameters in the API calls, which is a change to output.


[x] Output encoding is being done on a trusted system (the server)
[x] Sanitize all outputs of un-trusted data

