### PR TITLE
Rotated rw deploy key and added rubygems-access context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
             fi
       - add_ssh_keys:
           fingerprints:
-            - "5a:d3:92:32:b0:46:28:75:56:e9:ac:51:cc:44:31:82"
+            - "38:2a:c3:ec:03:84:bd:b0:75:93:9d:76:80:1f:c4:1c"
       - run:
           name: Bundle install
           command: bundle install
@@ -67,6 +67,8 @@ workflows:
       - deployment:
            requires:
              - test
+           context:
+             - rubygems-access
            filters:
              branches:
                only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ workflows:
            requires:
              - test
            context:
-             - rubygems-access
+             - rubygems-deploy
            filters:
              branches:
                only:


### PR DESCRIPTION
### Story Card: [MATS-80](https://healthfinch.atlassian.net/browse/MATS-80)

## Description of Change

Rotated the read/write deploy key used for deployment.

Added the `rubygems-deploy` context to the pipeline. Although this is the only pipeline to use the context, I still think it is valuable to have all of our secrets that are stored in circleci follow the same pattern.

## Testing Procedures to Verify the Functionality from this Change
_See Jira Card for testing details_

Since the pipeline will only use it's repo write access on prod pipeline runs, I had to come up with an alternative way to verify functionality. I tested the usage of the read/write deploy keys in the healthfinch-job repo. You can find a description of how I confirmed the read/write key was being used in [healthfinch-job: PR-51](https://github.com/healthfinch/healthfinch-job/pull/51). I don't think it necessary to repeat testing in this repo.

I have no way to test the context prior to merge, but you should see the context be passed to the agent when the pipeline is run.

## Description of Deployment and Rollback Procedures
### Deployment
- [x] Deployment follows standard [procedure](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/781189280/Deployment+Procedure+s)

If deployment does not follow standard procedure please explain the deployment process for this PR.


### Rollback
- [x] Rollback follows standard [procedure](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/779583813/Deployment+Rollback+Procedure+s)

If rollback does not follow standard procedure please explain the deployment process for this PR.

## Related Information (e.g., Pull requests, story cards, bug reports, metrics, logs, etc.):


## Process Checks

- [ ] Story card has been accepted by requester

- [ ] Local run of tests have been completed

- [ ] Has been deployed and tested in Stage

- [ ] This was worked on in a pair

If any of the above boxes were not checked please explain why:
Card not accepted prior to merge. No local test to run. No staging workflow to run. Zach solo.


## Security

[Secure Coding Guidelines](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/1271824607/Secure+Coding+Guidelines)
[Informational Security Policies](https://healthfinch.atlassian.net/wiki/spaces/COM/pages/33423408/Information+Security+Policies)

This Pull Request:

- Changes any external input or output
    - [ ] DOES
    - [x] DOES NOT
- Changes authentication, access control or password management
    - [ ] DOES
    - [x] DOES NOT
- Changes transmission or storage of secure data
    - [x] DOES
    - [ ] DOES NOT
- Changes error handling or logging
    - [ ] DOES
    - [x] DOES NOT
- Contains any database or data file changes
    - [ ] DOES
    - [x] DOES NOT

If DOES was answered for any of the above security questions, use the [Secure Coding Guidelines](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/1271824607/Secure+Coding+Guidelines) checklist and detail the results here:

We are storing secret environment variables using a different feature in circleci, but there is ultimately no change in the access the pipeline agents have or the secrets we store in circleci.

[MATS-80]: https://healthfinch.atlassian.net/browse/MATS-80?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ