### PR TITLE
We're not authenticating with every request now, that's handled when …

### DIFF
--- a/lib/allscripts_unity_client/json_client_driver.rb
+++ b/lib/allscripts_unity_client/json_client_driver.rb
@@ -48,10 +48,6 @@ module AllscriptsUnityClient
     end
 
     def magic(parameters = {})
-      unless user_authenticated? || parameters[:action] == 'GetUserAuthentication'
-        raise UnauthenticatedError, "#{parameters[:action]} for #{@options.base_unity_url}"
-      end
-
       request = JSONUnityRequest.new(parameters, @options.timezone, @options.appname, @security_token, @options.raw_dates)
       request_hash = request.to_hash
       request_data = MultiJson.dump(request_hash)

--- a/lib/allscripts_unity_client/version.rb
+++ b/lib/allscripts_unity_client/version.rb
@@ -1,3 +1,3 @@
 module AllscriptsUnityClient
-  VERSION = '5.1.2'.freeze
+  VERSION = '5.1.3'.freeze
 end

--- a/spec/json_client_driver_spec.rb
+++ b/spec/json_client_driver_spec.rb
@@ -82,19 +82,6 @@ describe AllscriptsUnityClient::JSONClientDriver do
         subject.magic(action: 'SomeRequest')
       end
     end
-
-    context 'when the user is not authenticated' do
-      before do
-        stub_request(:post, "http://www.example.com/Unity/UnityService.svc/json/MagicJson").
-          to_return(status: 200, body: get_server_info, headers: {})
-        allow(subject).to receive(:user_authenticated?).and_return(false)
-        subject.options.logger = fake_logger
-      end
-
-      it 'raises an UnauthenticatedError' do
-        expect{ subject.magic(action: 'SomeRequest') }.to raise_error(AllscriptsUnityClient::UnauthenticatedError)
-      end
-    end
   end
 
   describe '#get_security_token!' do


### PR DESCRIPTION
…we get the token initially and then reuse the cached token.

### Story Card: [SUST-600](https://healthfinch.atlassian.net/browse/SUST-600)

## Description of Change


## Testing Procedures to Verify the Functionality from this Change
_See Jira Card for testing details_


## Description of Deployment and Rollback Procedures
### Deployment
- [x] Deployment follows standard [procedure](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/781189280/Deployment+Procedure+s)

If deployment does not follow standard procedure please explain the deployment process for this PR.


### Rollback
- [x] Rollback follows standard [procedure](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/779583813/Deployment+Rollback+Procedure+s)

If rollback does not follow standard procedure please explain the deployment process for this PR.

## Related Information (e.g., Pull requests, story cards, bug reports, metrics, logs, etc.):


## Process Checks

- [ ] Story card has been accepted by requester

- [x] Local run of tests have been completed

- [x] Has been deployed and tested in Stage

- [x] This was worked on in a pair

If any of the above boxes were not checked please explain why:


## Security

[Secure Coding Guidelines](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/1271824607/Secure+Coding+Guidelines)
[Informational Security Policies](https://healthfinch.atlassian.net/wiki/spaces/COM/pages/33423408/Information+Security+Policies)

This Pull Request:

- Changes any external input or output
    - [ ] DOES
    - [x] DOES NOT
- Changes authentication, access control or password management
    - [ ] DOES
    - [x] DOES NOT
- Changes transmission or storage of secure data
    - [ ] DOES
    - [x] DOES NOT
- Changes error handling or logging
    - [ ] DOES
    - [x] DOES NOT
- Contains any database or data file changes
    - [ ] DOES
    - [x] DOES NOT

If DOES was answered for any of the above security questions, use the [Secure Coding Guidelines](https://healthfinch.atlassian.net/wiki/spaces/EN/pages/1271824607/Secure+Coding+Guidelines) checklist and detail the results here:


[SUST-600]: https://healthfinch.atlassian.net/browse/SUST-600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ